### PR TITLE
papis-scihub: Add new scihub domain (.tw)

### DIFF
--- a/examples/scripts/papis-scihub
+++ b/examples/scripts/papis-scihub
@@ -27,6 +27,7 @@ sci-hub.bz
 sci-hub.io
 sci-hub.cc
 sci-hub.ac
+sci-hub.tw
 sci-hub.biz
 )
 


### PR DESCRIPTION
Today sci-hub io, bz, biz, ac and cc seems down, while tw is working