### PR TITLE
New config flag: ref-format

### DIFF
--- a/papis/config.py
+++ b/papis/config.py
@@ -1,5 +1,4 @@
-"""
-General
+"""General
 *******
 
 .. papis-config:: local-config-file
@@ -269,6 +268,17 @@ General
     Since we should be living in an unicode world, it is set to ``True``
     by default.
 
+.. papis-config:: ref-format
+
+    This flag is set to change the ``ref`` flag in the info.yaml file
+    when a document is imported. For example: I prefer the format
+    FirstAuthorYear e.g. Plews2019. This would be achieved by the
+    following:
+
+        ``ref-format = {doc[author_list][0][surname]}{doc[year]}``
+
+    The default behaviour is to set the doi as the ref.
+
 """
 import logging
 
@@ -361,6 +371,7 @@ general_settings = {
         "{doc[title]:<70.70}|{doc[author]:<20.20} ({doc[year]:-<4})",
 
     "info-allow-unicode": True,
+    "ref-format"      : "{doc[doi]}",
 }
 
 

--- a/papis/config.py
+++ b/papis/config.py
@@ -1,4 +1,5 @@
-"""General
+"""
+General
 *******
 
 .. papis-config:: local-config-file

--- a/papis/crossref.py
+++ b/papis/crossref.py
@@ -334,7 +334,7 @@ def get_cross_ref(doi):
     res.update(get_citation_info_from_results(record))
 
     # REFERENCE BUILDING
-    res["ref"] = doi
+    res['ref'] = papis.utils.format_doc(papis.config.get("ref-format"), res)
 
     # Journal checking
     # If the key journal does not exist check for abbrev_journal_title


### PR DESCRIPTION
This PR brings the implementation of the `ref-format` flag. This allows the user to set their preferred format to reference when using in conjunction with .bib files. Or for remembering a article by an easy to remember combination of information (e.g. AuthorYear) rather than the doi.

The default behaviour is for the ref to be set to the doi.

Closes #16  